### PR TITLE
Support private Route53 zones

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,81 @@
+# Some of this logic was stolen from https://www.freecodecamp.org/news/a-lightweight-tool-agnostic-ci-cd-flow-with-github-actions/
+
+name: terraform
+
+on:
+  push:
+#   branches:
+#     - master
+  pull_request:
+
+jobs:
+  terraform:
+    name: terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: terraform setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.12.29
+      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+#     TODO: This step duplicates work done by the Makefile.
+#     - name: check terraform formatting
+#       id: fmt
+#       run: |
+#         terraform fmt -check -recursive
+
+      - name: run make
+      # env:
+      #   TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          make all
+
+#     - name: terraform init
+#       id: init
+#       run: terraform init
+#
+#      - name: terraform plan
+#        id: plan
+#        if: github.event_name == 'pull_request'
+#        run: terraform plan -no-color
+#        continue-on-error: true
+#
+#      - uses: actions/github-script@0.9.0
+#        if: github.event_name == 'pull_request'
+#        env:
+#          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          script: |
+#            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+#            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+#            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+#
+#            <details><summary>Show Plan</summary>
+#
+#            \`\`\`${process.env.PLAN}\`\`\`
+#
+#            </details>
+#
+#            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+#
+#            github.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: output
+#            })
+#
+#      - name: terraform plan status
+#        if: steps.plan.outcome == 'failure'
+#        run: exit 1
+#
+#      - name: terraform apply
+#        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+#        run: terraform apply -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 REPO := $(shell basename $(shell git remote get-url origin) .git)
 
+all: test
+
 test: .terraform
 	AWS_DEFAULT_REGION=us-east-2 terraform validate
 	terraform fmt -check
@@ -19,8 +21,8 @@ test: .terraform
 	! egrep 'output\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name outputs.tf)
 	# Do NOT define a variable in files other than variables.tf
 	! egrep 'variable\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name variables.tf)
-	# DO put a badge in README.md
-	grep -q "\[\!\[Build Status\]([^)]*$(REPO)/status.svg)\]([^)]*$(REPO))" README.md
+	# DO put a badge in top-level README.md
+	grep -q "\[\!\[Terraform actions status\]([^)]*$(REPO)/workflows/terraform/badge.svg)\]([^)]*$(REPO)/actions)" README.md
 	# Do NOT use ?ref= in source lines in a README.md!
 	! grep 'source\s*=.*?ref=' *.tf README.md
 	# Do NOT start a source line with git::

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://drone.techservices.illinois.edu/api/badges/techservicesillinois/terraform-aws-ec2/status.svg)](https://drone.techservices.illinois.edu/techservicesillinois/terraform-aws-ec2)
+[![Terraform actions status](https://github.com/techservicesillinois/terraform-aws-ec2/workflows/terraform/badge.svg)](https://github.com/techservicesillinois/terraform-aws-ec2/actions)
 
 # ec2
 
@@ -155,6 +155,9 @@ is to be created.
 specified Route 53 zone. Default: the EC2 instance name (i.e., what
 appears in the `name` attribute).
 
+* `private_zone` – (Optional) Specify if the alias is to reside in a 
+private zone inside the virtual private cloud (VPC). Default: false.
+
 * `ttl` - (Optional) Time in seconds for DNS lookup to be cached. Default: 60.
 
 Note that if the `hostname` is omitted, it will default to the `name`
@@ -199,16 +202,21 @@ EC2 instance. Set to false if the Elastic IP already exists and is to be looked 
 
 Template variables
 -------
-The following variables are passed to the `user_data` template, and are therefore
-available to the process by which the virtual host is provisioned.
+The following variables are passed to the `user_data` template, and are
+therefore available to the process by which the virtual host is provisioned.
 
 * `ebs_device_name`
 * `ebs_mount_point`
 * `efs_file_system_name`
 * `efs_mount_point`
 * `efs_source_path`
+* `hostname`
 
-For details about the data populated into these variables, please see the descriptions above for the [ebs\_volume](#ebs_volume) and [efs\_file\_system](#efs_file_system) blocks.
+For details about the data populated into the `ebs_` and `efs_` variables,
+please see the descriptions above for the [ebs\_volume](#ebs_volume) and [efs\_file\_system](#efs_file_system) blocks.
+
+The `hostname` contains a fully-qualified domain name computed from the
+first entry in the `alias` block, if any is defined.
 
 Attributes Reference
 --------------------

--- a/data.tf
+++ b/data.tf
@@ -67,18 +67,20 @@ locals {
   efs_file_system_id = lookup(var.efs_file_system, "file_system_id", "")
   efs_mount_point    = lookup(var.efs_file_system, "mount_point", "")
   efs_source_path    = lookup(var.efs_file_system, "source_path", "")
+  hostname           = length(var.alias) > 0 ? format("%s.%s", lookup(var.alias[0], "hostname", var.name), var.alias[0].domain) : null
 }
 
 data "template_file" "selected" {
   template = file(var.template_file)
 
+  # Pass hostname (fully-qualified domain name), and EBS and EFS variables
+  # to template.
   vars = {
-    # EBS variables.
-    ebs_device_name = local.ebs_device_name
-    ebs_mount_point = local.ebs_mount_point
-    # EFS variables.
+    ebs_device_name      = local.ebs_device_name
+    ebs_mount_point      = local.ebs_mount_point
     efs_file_system_name = local.fqdn_efs
     efs_mount_point      = local.efs_mount_point
     efs_source_path      = local.efs_source_path
+    hostname             = local.hostname
   }
 }

--- a/eip.tf
+++ b/eip.tf
@@ -10,6 +10,10 @@ locals {
   # get name of EIP from the eip map, or default to name of the EC2 instance
   eip_name = lookup(var.eip, "name", null) != null ? lookup(var.eip, "name") : var.name
 
+  private_ip = local.want_eip ? element(concat(aws_eip.default.*.private_ip, data.aws_eip.selected.*.private_ip, [""]), 0) : aws_instance.default.private_ip
+
+  private_dns = local.want_eip ? element(concat(aws_eip.default.*.private_dns, data.aws_eip.selected.*.private_dns, [""]), 0) : aws_instance.default.private_dns
+
   public_ip = local.want_eip ? element(concat(aws_eip.default.*.public_ip, data.aws_eip.selected.*.public_ip, [""]), 0) : aws_instance.default.public_ip
 
   public_dns = local.want_eip ? element(concat(aws_eip.default.*.public_dns, data.aws_eip.selected.*.public_dns, [""]), 0) : aws_instance.default.public_dns

--- a/route53.tf
+++ b/route53.tf
@@ -1,7 +1,9 @@
 data "aws_route53_zone" "selected" {
   count = length(var.alias)
 
-  name = lookup(var.alias[count.index], "domain", "")
+  name         = var.alias[count.index].domain
+  vpc_id       = lookup(var.alias[count.index], "private_zone", false) ? data.aws_vpc.selected.id : null
+  private_zone = lookup(var.alias[count.index], "private_zone", false)
 }
 
 resource "aws_route53_record" "default" {
@@ -11,5 +13,5 @@ resource "aws_route53_record" "default" {
   name    = lookup(var.alias[count.index], "hostname", var.name)
   type    = "A"
   ttl     = lookup(var.alias[count.index], "ttl", 60)
-  records = [local.public_ip]
+  records = [lookup(var.alias[count.index], "private_zone", false) ? local.private_ip : local.public_ip]
 }


### PR DESCRIPTION
*   Module now supports private Route53 zones. In this case, the A record is set to the private rather than public IP.

*   One can now set "associate_public_ip_address" to false for instances that don't have public Route53 presence.

These discoveries were made in the course of testing networking for a new VPC.