### PR TITLE
Enhancements to root EBS volume configuration

### DIFF
--- a/ebs.tf
+++ b/ebs.tf
@@ -4,9 +4,10 @@ locals {
 }
 
 resource "aws_volume_attachment" "default" {
-  count        = length(var.ebs_volume) > 0 ? 1 : 0
-  skip_destroy = true
+  count = length(var.ebs_volume) > 0 ? 1 : 0
+
   device_name  = var.ebs_volume["device_name"]
-  volume_id    = var.ebs_volume["volume_id"]
   instance_id  = aws_instance.default.id
+  skip_destroy = true
+  volume_id    = var.ebs_volume["volume_id"]
 }

--- a/eip.tf
+++ b/eip.tf
@@ -33,13 +33,13 @@ data "aws_eip" "selected" {
 resource "aws_eip" "default" {
   count = local.want_eip && local.eip_create ? 1 : 0
 
-  tags = merge(var.tags, { "Name" = local.eip_name })
+  tags = merge(var.tags, { Name = local.eip_name })
 }
 
 # Attach the EIP (whether created or looked up) to the EC2 instance
 resource "aws_eip_association" "eip_assoc" {
   count = local.want_eip ? 1 : 0
 
-  instance_id   = aws_instance.default.id
   allocation_id = local.eip_create ? aws_eip.default[0].id : data.aws_eip.selected[0].id
+  instance_id   = aws_instance.default.id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,30 @@
 resource "aws_instance" "default" {
-  ami               = data.aws_ami.selected.id
-  instance_type     = var.instance_type
-  availability_zone = local.availability_zone
-  key_name          = var.key_name
+  ami                         = data.aws_ami.selected.id
+  associate_public_ip_address = var.associate_public_ip_address
+  availability_zone           = local.availability_zone
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  private_ip                  = var.private_ip
+  subnet_id                   = local.subnet_id
+  tags                        = merge({ Name = var.name }, var.tags)
+  user_data                   = data.template_file.selected.rendered
 
   vpc_security_group_ids = concat(
     [aws_security_group.default.id],
     flatten(data.aws_security_groups.selected.*.ids),
   )
 
-  private_ip                  = var.private_ip
-  subnet_id                   = local.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
-  user_data                   = data.template_file.selected.rendered
-  tags                        = merge({ "Name" = var.name }, var.tags)
+  dynamic "root_block_device" {
+    for_each = [var.root_block_device]
+    content {
+      delete_on_termination = root_block_device.value.delete_on_termination
+      encrypted             = root_block_device.value.encrypted
+      iops                  = root_block_device.value.iops
+      kms_key_id            = root_block_device.value.kms_key_id
+      tags                  = merge(var.tags, { Name = format("%s:%s", var.name, "root") })
+      throughput            = root_block_device.value.throughput
+      volume_size           = root_block_device.value.volume_size
+      volume_type           = root_block_device.value.volume_type
+    }
+  }
 }

--- a/sg.tf
+++ b/sg.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "default" {
   description = "EC2 instance ${var.name} security group"
   name        = var.name
   vpc_id      = local.vpc_id
-  tags        = merge({ "Name" = var.name }, var.tags)
+  tags        = merge({ Name = var.name }, var.tags)
 }
 
 resource "aws_security_group_rule" "in_tcp" {

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,21 @@ variable "ports" {
   default     = []
 }
 
+variable "root_block_device" {
+  description = "Definition for instance's root block device"
+  type = object({
+    delete_on_termination = optional(bool)
+    encrypted             = optional(bool)
+    iops                  = optional(number)
+    kms_key_id            = optional(string)
+    throughput            = optional(number)
+    volume_size           = optional(number)
+    volume_type           = optional(string)
+  })
+  default = {
+  }
+}
+
 variable "subnet_type" {
   description = "Subnet type (e.g., 'campus', 'private', 'public') for resource placement"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.4"
 }


### PR DESCRIPTION
*   Add root_block_device dynamic block to allow configuring root volume.

*   Add tags to root block_device.

Still need to resolve tagging and configuration for other, non-root EBS volumes. It's uncertain whether declaring EBS volumes separately in terraform-aws-ebs-volume is still the best approach.